### PR TITLE
Update README to reflect current state of the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,70 @@
+# Unearth
+
+A weekly media discovery platform built with Astro 5. Unearth curates and displays media recommendations each week — text, video, audio, images, and more — powered by a Notion backend.
+
+## Features
+
+- **Weekly media feed** — Browse curated recommendations refreshed every Sunday
+- **Rich embeds** — YouTube, Vimeo, Spotify, SoundCloud, and direct image previews
+- **Community submissions** — Anyone can recommend media via the submit form
+- **Server-side rendering** — Fast, SEO-friendly pages via Astro SSR on Vercel
+
+## Tech Stack
+
+| Layer | Technology |
+| :--- | :--- |
+| Framework | [Astro 5](https://astro.build/) (SSR) |
+| Styling | Tailwind CSS 4 + DaisyUI 5 + `@tailwindcss/typography` |
+| Data | [Notion API](https://developers.notion.com/) (DataSources API) |
+| Forms | Astro Actions + Zod validation |
+| Testing | Vitest |
+| Deployment | Vercel |
+| CI | GitHub Actions (weekly Sunday redeploy) |
+
+## Project Structure
+
 ```text
-/
-├── public/
-│   └── favicon.svg
-├── src
-│   ├── assets
-│   │   └── astro.svg
-│   ├── components
-│   │   └── Welcome.astro
-│   ├── layouts
-│   │   └── BaseLayout.astro
-│   └── pages
-│       └── index.astro
-└── package.json
+src/
+├── actions/          # Server-side form handlers (Astro Actions)
+├── components/       # Astro components (MediaCard, MediaModal, SubmitForm, etc.)
+│   ├── __tests__/    # Component tests
+│   └── media/        # Embed sub-components (VideoEmbed, AudioEmbed, etc.)
+├── layouts/          # BaseLayout with nav, analytics, background
+├── lib/              # Core logic
+│   ├── __tests__/    # Library tests
+│   ├── dateHelpers.ts
+│   ├── embedHelpers.ts
+│   ├── imageDownloader.ts
+│   ├── notion.ts
+│   └── notionMapper.ts
+├── pages/            # File-based routing (index, submit)
+├── styles/           # Global CSS with Tailwind layers
+└── types/            # Shared TypeScript types
 ```
 
-All commands are run from the root of the project, from a terminal:
+## Getting Started
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `bun install`             | Installs dependencies                            |
-| `bun dev`             | Starts local dev server at `localhost:4321`      |
-| `bun build`           | Build your production site to `./dist/`          |
-| `bun preview`         | Preview your build locally, before deploying     |
-| `bun astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `bun astro -- --help` | Get help using the Astro CLI                     |
+### Prerequisites
 
+- [Bun](https://bun.sh/)
+- A [Notion integration](https://developers.notion.com/docs/create-a-notion-integration) with access to your databases
+
+### Environment Variables
+
+```env
+NOTION_TOKEN=
+NOTION_SUBMISSION_DB_ID=
+NOTION_MEDIA_DB_ID=
+NOTION_MEDIA_DATASOURCE_ID=
+```
+
+### Commands
+
+| Command | Action |
+| :--- | :--- |
+| `bun install` | Install dependencies |
+| `bun dev` | Start dev server at `localhost:4321` |
+| `bun run build` | Production build to `./dist/` |
+| `bun run preview` | Preview production build |
+| `bun run test` | Run tests (Vitest) |
+| `bun run test:watch` | Run tests in watch mode |


### PR DESCRIPTION
Replace the default Astro starter README with documentation that
accurately describes Unearth: tech stack, project structure,
environment variables, and available commands.

Closes #12

https://claude.ai/code/session_01RAKEArysz14TB5PHgvc5Kd