### PR TITLE
Add OpenGraph, SEO, and meta tags to all pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -19,10 +19,6 @@ const {
 } = Astro.props;
 
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
-}
-
-const { title } = Astro.props;
-const pageTitle = title ? `${title} | unearth.club` : "unearth.club";
 ---
 
 <!doctype html>
@@ -54,7 +50,6 @@ const pageTitle = title ? `${title} | unearth.club` : "unearth.club";
 		<meta name="theme-color" content="#faf8f5" />
 		<link rel="preload" href="/UT Bekidos.ttf" as="font" type="font/truetype" crossorigin />
 		<link rel="preload" href="/FacultyGlyphic-Regular.ttf" as="font" type="font/truetype" crossorigin />
-		<title>{pageTitle}</title>
 	</head>
 	<body>
 		<a href="#main-content" class="skip-link">Skip to content</a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -3,6 +3,22 @@ import "../styles/app.css";
 import Analytics from "@vercel/analytics/astro";
 import SpeedInsights from "@vercel/speed-insights/astro";
 import BackgroundImage from "@components/Background.astro";
+
+interface Props {
+	title?: string;
+	description?: string;
+	ogImage?: string;
+}
+
+const siteName = "unearth.club";
+const siteUrl = "https://unearth.club";
+const {
+	title = siteName,
+	description = "Weekly curated media discoveries — videos, articles, music, and more worth sharing.",
+	ogImage = `${siteUrl}/og-image.png`,
+} = Astro.props;
+
+const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 ---
 
 <!doctype html>
@@ -11,8 +27,26 @@ import BackgroundImage from "@components/Background.astro";
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<link rel="canonical" href={canonicalUrl} />
 		<meta name="generator" content={Astro.generator} />
-		<title>unearth.club</title>
+
+		<!-- SEO -->
+		<title>{title}</title>
+		<meta name="description" content={description} />
+
+		<!-- Open Graph -->
+		<meta property="og:type" content="website" />
+		<meta property="og:url" content={canonicalUrl} />
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:site_name" content={siteName} />
+		<meta property="og:image" content={ogImage} />
+
+		<!-- Twitter -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
+		<meta name="twitter:image" content={ogImage} />
 	</head>
 	<body>
 		<BackgroundImage>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import MediaCard from "@components/MediaCard.astro";
 const pages = await getCurrentWeekMedia();
 ---
 
-<Layout>
+<Layout title="unearth.club — Weekly Media Discoveries" description="Browse this week's curated media recommendations — videos, articles, music, and more worth sharing.">
 	<WeekIndicator />
 
 	{

--- a/src/pages/submit.astro
+++ b/src/pages/submit.astro
@@ -3,7 +3,7 @@ import Layout from "@layouts/BaseLayout.astro";
 import SubmitForm from "@components/SubmitForm.astro";
 ---
 
-<Layout>
+<Layout title="Submit — unearth.club" description="Share media that moved, surprised, or taught you something. Submit your recommendation to unearth.club.">
 	<div class="submit-page">
 		<h2>Submit something worth discovering</h2>
 		<p class="subtitle">Share media that moved, surprised, or taught you something.</p>


### PR DESCRIPTION
- Update BaseLayout to accept title, description, and ogImage props
- Add canonical URL, Open Graph, and Twitter Card meta tags
- Set page-specific metadata on index and submit pages
- Include sensible defaults so pages work without explicit props

Closes #3

https://claude.ai/code/session_01RAKEArysz14TB5PHgvc5Kd